### PR TITLE
rearrange args & use real tempdir in c tests

### DIFF
--- a/lib/uplinkc/testdata/helpers.h
+++ b/lib/uplinkc/testdata/helpers.h
@@ -30,6 +30,7 @@ void with_test_project(void (*handleProject)(ProjectRef)) {
 
     char *satellite_addr = getenv("SATELLITE_0_ADDR");
     char *apikeyStr = getenv("GATEWAY_0_API_KEY");
+    char *tmp_dir = getenv("TMP_DIR");
 
     printf("using SATELLITE_0_ADDR: %s\n", satellite_addr);
     printf("using GATEWAY_0_API_KEY: %s\n", apikeyStr);
@@ -39,7 +40,7 @@ void with_test_project(void (*handleProject)(ProjectRef)) {
         cfg.Volatile.tls.skip_peer_ca_whitelist = true; // TODO: add CA Whitelist
 
         // New uplink
-        UplinkRef uplink = new_uplink(cfg, err, "inmemory");
+        UplinkRef uplink = new_uplink(cfg, tmp_dir, err);
         require_noerror(*err);
         requiref(uplink._handle != 0, "got empty uplink\n");
 

--- a/lib/uplinkc/testdata_test.go
+++ b/lib/uplinkc/testdata_test.go
@@ -81,6 +81,7 @@ func TestC(t *testing.T) {
 					cmd.Env = append(os.Environ(),
 						"SATELLITE_0_ADDR="+planet.Satellites[0].Addr(),
 						"GATEWAY_0_API_KEY="+planet.Uplinks[0].APIKey[planet.Satellites[0].ID()].Serialize(),
+						"TMP_DIR"+ctx.Dir("c_temp"),
 					)
 
 					out, err := cmd.CombinedOutput()

--- a/lib/uplinkc/uplink.go
+++ b/lib/uplinkc/uplink.go
@@ -23,7 +23,7 @@ type Uplink struct {
 // an error in cerr, when there is one.
 //
 // Caller must call close_uplink to close associated resources.
-func new_uplink(cfg C.UplinkConfig, cerr **C.char, tempDir *C.char) C.UplinkRef {
+func new_uplink(cfg C.UplinkConfig, tempDir *C.char, cerr **C.char) C.UplinkRef {
 	scope := rootScope(C.GoString(tempDir))
 
 	libcfg := &uplink.Config{} // TODO: figure out a better name


### PR DESCRIPTION
- Move temp-dir arg to second from last, last is consistently the error double-pointer.
- Use real temp dir in c tests.